### PR TITLE
Don't report errors when there aren't any [DEV-223]

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
- "extends": "@bubkoo/tsconfig",
+  "extends": "@bubkoo/tsconfig",
   "include": [
     "src/**/*.ts"
   ]


### PR DESCRIPTION
Currently, when dealing with CORS CSS many errors where printed to console. Those where either not really errors (like `Cannot inline remote CSS`) or could be avoided if handled properly (like `Error while reading CSS rules from ...`).

### Description

When fetching CORS CSS we'll replace the unaccessible entry in `styleSheets` array with the one we fetched. This will avoid outputing errors in the second rule-parsing loop which was really not needed.

### Motivation and Context

Outputing error when it's not really an error is confusing and should not be done.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
