### PR TITLE
Don't fail on missing src attribute

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-registry=https://nexus.celtra.com/repository/npm/
-always-auth=true
-//nexus.celtra.com/repository/npm/:_auth=YnVpbGQ6UWZtZlo4RDJ2SGlaWlJGNllQS25KZzd6M25VR2E4R0ZLUXVaaXhGaGd0QmJYN1c0
-devdir=/cache/npm

--- a/src/embed-images.ts
+++ b/src/embed-images.ts
@@ -44,9 +44,9 @@ async function embedImageNode<T extends HTMLElement | SVGImageElement>(
   // which has an empty value will return the current URL.
   // This is a workaround to prevent the loading of current page URL as an image when there are empty images in the DOM.
   if (
-    (isImageElement && clonedNode.getAttribute('src') === '') ||
+    (isImageElement && !clonedNode.getAttribute('src')) ||
     (isInstanceOfElement(clonedNode, SVGImageElement) &&
-      clonedNode.getAttribute('href') === '')
+      !clonedNode.getAttribute('href'))
   ) {
     return
   }

--- a/src/embed-images.ts
+++ b/src/embed-images.ts
@@ -41,7 +41,7 @@ async function embedImageNode<T extends HTMLElement | SVGImageElement>(
   const isImageElement = isInstanceOfElement(clonedNode, HTMLImageElement)
 
   // Skip images with empty sources. Note that reading the src property of an HTMLImageElement (or href of SVGImageElement)
-  // which has an empty value will return the current URL.
+  // which has an empty or missing value will return the current URL.
   // This is a workaround to prevent the loading of current page URL as an image when there are empty images in the DOM.
   if (
     (isImageElement && !clonedNode.getAttribute('src')) ||

--- a/test/resources/images/node-empty.html
+++ b/test/resources/images/node-empty.html
@@ -1,2 +1,3 @@
 <img src="" />
+<img />
 <img src="/base/test/resources/images/image.png" />

--- a/test/resources/svg-image/node-empty.html
+++ b/test/resources/svg-image/node-empty.html
@@ -14,4 +14,8 @@
     width="200"
     href=""
   />
+  <image
+    height="200"
+    width="200"
+  />
 </svg>


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.11.16--canary.8.74e1990.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @celtra/html-to-image@1.11.16--canary.8.74e1990.0
  # or 
  yarn add @celtra/html-to-image@1.11.16--canary.8.74e1990.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
